### PR TITLE
Bug in NSURLRequest formation

### DIFF
--- a/RequestUtils/RequestUtils.m
+++ b/RequestUtils/RequestUtils.m
@@ -313,7 +313,7 @@ NSString *const URLFragmentComponent = @"fragment";
     }
     else
     {
-        result = [result stringByAppendingFormat:@"?%@", query];
+        result = [result stringByAppendingFormat:@"%@", query];
     }
     if ([fragment length])
     {


### PR DESCRIPTION
Using [NSMutableURLRequest GETRequestWithURL: parameters:] where both URL and parameters are valid causes a generated URL which would have a double ?? in it. This might break other uses of string by AppendingURLQuery, which I have not checked yet. But in any case, (I feel) a generated URL query should _not_ have a ? prefix. Adding a ? as prefix should be the responsibility of the caller, not the query string generation function.
