### PR TITLE
fix query parameter parse error when url like 'meituanmovie://www.meitua...

### DIFF
--- a/RequestUtils/RequestUtils.m
+++ b/RequestUtils/RequestUtils.m
@@ -460,37 +460,6 @@
             value = @[value];
         }
         result[key] = value;
-        
-//        if ([parts count] > 1)
-//        {
-//            id value = [parts[1] URLDecodedString:YES];
-//            BOOL arrayValue = [key hasSuffix:@"[]"];
-//            if (arrayValue)
-//            {
-//                key = [key substringToIndex:[key length] - 2];
-//            }
-//            id existingValue = result[key];
-//            if ([existingValue isKindOfClass:[NSArray class]])
-//            {
-//                value = [existingValue arrayByAddingObject:value];
-//            }
-//            else if (existingValue)
-//            {
-//                if (options == URLQueryOptionKeepFirstValue)
-//                {
-//                    value = existingValue;
-//                }
-//                else if (options != URLQueryOptionKeepLastValue)
-//                {
-//                    value = @[existingValue, value];
-//                }
-//            }
-//            else if ((arrayValue && options == URLQueryOptionUseArrays) || options == URLQueryOptionAlwaysUseArrays)
-//            {
-//                value = @[value];
-//            }
-//            result[key] = value;
-//        }
     }
     return result;
 }


### PR DESCRIPTION
Given that i have a url like 'meituanmovie://www.meituan.com/web?url=http://test1.m.maoyan.com/newGuide/12?f=ios' , if i call 

```
NSDictionary *params = [[URL absoluteString] URLQueryParameters];
```

then the params = @{@"url" : @"http://test1.m.maoyan.com/newGuide/12?f"};
Then result is error
