### PR TITLE
fix query start wrong when fragment has query

### DIFF
--- a/RequestUtils/RequestUtils.m
+++ b/RequestUtils/RequestUtils.m
@@ -268,7 +268,7 @@
     {
         queryRange.length -= (queryRange.length - fragmentStart.location);
     }
-    NSRange queryStart = [self rangeOfString:@"?"];
+    NSRange queryStart = [[self substringWithRange:queryRange] rangeOfString:@"?"];
     if (queryStart.length)
     {
         queryRange.location = queryStart.location;


### PR DESCRIPTION
if there are same query string after fragment. for example. http://sample.com/?a=1#/index?b=2. the rangeOfURLQuery will get wrong value.
