### PR TITLE
Adding watchOS target in the podspec

### DIFF
--- a/RequestUtils.podspec.json
+++ b/RequestUtils.podspec.json
@@ -13,6 +13,7 @@
   "requires_arc": true,
   "platforms": {
     "osx": "10.6",
-    "ios": "4.3"
+    "ios": "4.3",
+    "watchos": "2.0"
   }
 }


### PR DESCRIPTION
In order to use this awesome pod in watchOS 2 the pod spec has to be extended to include watchOS target