### PR TITLE
Use and expose NSString + NSCharacterSet based string encoding when available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Tests/RequestUtilsTests.xcodeproj/xcuserdata

--- a/RequestUtils/RequestUtils.h
+++ b/RequestUtils/RequestUtils.h
@@ -152,6 +152,11 @@ typedef NS_ENUM(NSUInteger, URLQueryOptions)
 
 @end
 
+@interface NSDictionary(RequestUtils)
+- (NSArray <NSURLQueryItem *>*) URLQueryItems;
+- (NSURLComponents *) urlComponentsWithBaseURLString:(NSString *)baseURL;
+@end
+
 
 @interface NSURLRequest (RequestUtils)
 

--- a/RequestUtils/RequestUtils.h
+++ b/RequestUtils/RequestUtils.h
@@ -158,6 +158,9 @@ typedef NS_ENUM(NSUInteger, URLQueryOptions)
 + (instancetype)HTTPRequestWithURL:(NSURL *)URL method:(NSString *)method parameters:(NSDictionary<NSString *, id> *)parameters;
 + (instancetype)GETRequestWithURL:(NSURL *)URL parameters:(NSDictionary<NSString *, id> *)parameters;
 + (instancetype)POSTRequestWithURL:(NSURL *)URL parameters:(NSDictionary<NSString *, id> *)parameters;
++ (instancetype)HTTPRequestWithString:(NSString *)URL method:(NSString *)method parameters:(NSDictionary<NSString *, id> *)parameters;
++ (instancetype)GETRequestWithString:(NSString *)URL parameters:(NSDictionary<NSString *, id> *)parameters;
++ (instancetype)POSTRequestWithString:(NSString *)URL parameters:(NSDictionary<NSString *, id> *)parameters;
 
 @property (nonatomic, readonly, nullable) NSDictionary<NSString *, NSString *> *GETParameters;
 @property (nonatomic, readonly, nullable) NSDictionary<NSString *, NSString *> *POSTParameters;

--- a/RequestUtils/RequestUtils.h
+++ b/RequestUtils/RequestUtils.h
@@ -71,6 +71,14 @@ typedef NS_ENUM(NSUInteger, URLQueryOptions)
 
 #pragma mark URLEncoding
 
+#if (__MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9) || (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0)
+@property (nullable, nonatomic, readonly) NSString *URLQueryEncodedString;
+@property (nullable, nonatomic, readonly) NSString *URLPathEncodedString;
+@property (nullable, nonatomic, readonly) NSString *URLHostEncodedString;
+@property (nullable, nonatomic, readonly) NSString *URLUserEncodedString;
+@property (nullable, nonatomic, readonly) NSString *URLPasswordEncodedString;
+@property (nullable, nonatomic, readonly) NSString *URLFragmentEncodedString;
+#endif
 @property (nonatomic, readonly) NSString *URLEncodedString;
 @property (nonatomic, readonly) NSString *URLDecodedString;
 

--- a/RequestUtils/RequestUtils.m
+++ b/RequestUtils/RequestUtils.m
@@ -58,6 +58,42 @@
 
 #pragma mark URLEncoding
 
+- (NSString *)URLQueryEncodedString{
+#if !(__MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9) && !(__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0)
+    return [self URLEncodedString];
+#endif
+    return [self stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+}
+- (NSString *)URLPathEncodedString{
+#if !(__MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9) && !(__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0)
+    return [self URLEncodedString];
+#endif
+    return [self stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]];
+}
+- (NSString *)URLHostEncodedString{
+#if !(__MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9) && !(__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0)
+    return [self URLEncodedString];
+#endif
+    return [self stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+}
+- (NSString *)URLUserEncodedString{
+#if !(__MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9) && !(__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0)
+    return [self URLEncodedString];
+#endif
+    return [self stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLUserAllowedCharacterSet]];
+}
+- (NSString *)URLPasswordEncodedString{
+#if !(__MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9) && !(__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0)
+    return [self URLEncodedString];
+#endif
+    return [self stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPasswordAllowedCharacterSet]];
+}
+- (NSString *)URLFragmentEncodedString{
+#if !(__MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9) && !(__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0)
+    return [self URLEncodedString];
+#endif
+    return [self stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLFragmentAllowedCharacterSet]];
+}
 - (NSString *)URLEncodedString
 {
     static NSString *const unsafeChars = @"!*'\"();:@&=+$,/?%#[]% ";

--- a/RequestUtils/RequestUtils.m
+++ b/RequestUtils/RequestUtils.m
@@ -770,6 +770,23 @@
 
 @end
 
+@implementation NSDictionary(RequestUtils)
+- (NSArray <NSURLQueryItem *>*) URLQueryItems{
+    NSMutableArray * arrItems = [NSMutableArray arrayWithCapacity:self.allKeys.count];
+    [self enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
+#pragma unused(stop)
+        NSURLQueryItem * queryItem = [NSURLQueryItem queryItemWithName:key value:obj];
+        [arrItems addObject:queryItem];
+    }];
+    return arrItems;
+}
+- (NSURLComponents *) urlComponentsWithBaseURLString:(NSString *)baseURL{
+    NSURLComponents * components = [NSURLComponents componentsWithString:baseURL];
+    components.queryItems = [self URLQueryItems];
+    return components;
+}
+@end
+
 
 @implementation NSURLRequest (RequestUtils)
 

--- a/RequestUtils/RequestUtils.m
+++ b/RequestUtils/RequestUtils.m
@@ -804,6 +804,19 @@
 {
     return [self HTTPRequestWithURL:URL method:@"POST" parameters:parameters];
 }
++ (instancetype)HTTPRequestWithString:(NSString *)URL method:(NSString *)method parameters:(NSDictionary<NSString *, id> *)parameters{
+    NSURL * convertedURL = URL.URLValue;
+    if (!convertedURL) {
+        return nil;
+    }
+    return [self HTTPRequestWithURL:convertedURL method:method parameters:parameters];
+}
++ (instancetype)GETRequestWithString:(NSString *)URL parameters:(NSDictionary<NSString *, id> *)parameters{
+    return [self HTTPRequestWithString:URL method:@"GET" parameters:parameters];
+}
++ (instancetype)POSTRequestWithString:(NSString *)URL parameters:(NSDictionary<NSString *, id> *)parameters{
+    return [self HTTPRequestWithString:URL method:@"POST" parameters:parameters];
+}
 
 - (nullable NSDictionary<NSString *, NSString *> *)GETParameters
 {

--- a/Tests/RequestUtilsTests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Tests/RequestUtilsTests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
In this way, we can eliminate our own string encoding, which is provided correctly, beginning iOS 7.

Please check and merge only if it's eligible / makes sense to you.

Thanks!
